### PR TITLE
Fix compile error due to wrong Eigen Vector type

### DIFF
--- a/ICP.h
+++ b/ICP.h
@@ -345,7 +345,7 @@ namespace SICP {
                     if(dual < par.stop) break;
                 }
                 /// C update (lagrange multipliers)
-                Eigen::VectorXf P = (Qn.array()*(X-Qp).array()).colwise().sum().transpose()-Z.array();
+                Eigen::VectorXd P = (Qn.array()*(X-Qp).array()).colwise().sum().transpose()-Z.array();
                 if(!par.use_penalty) C.noalias() += mu*P;
                 /// mu update (penalty)
                 if(mu < par.max_mu) mu *= par.alpha;


### PR DESCRIPTION
Just a simple compilation fix.

Eigen version is the one bundled with the SparseICP code (sparseicp/include/Eigen/, v 3.2.1).
