### PR TITLE
Compatibility fix with nanoflan 1.1.9 and later.

### DIFF
--- a/ICP.h
+++ b/ICP.h
@@ -32,7 +32,7 @@ namespace nanoflann {
         index_t* index;
         KDTreeAdaptor(const MatrixType &mat, const int leaf_max_size = 10) : m_data_matrix(mat) {
             const size_t dims = mat.rows();
-            index = new index_t( dims, *this, nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size, dims ) );
+            index = new index_t( dims, *this, nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size) );
             index->buildIndex();
         }
         ~KDTreeAdaptor() {delete index;}


### PR DESCRIPTION
Nanoflann has removed `KDTreeSingleIndexAdaptorParams::dim` since version 1.1.9 [[1]].  This update ensure ICP.h compiles with newer versions of nanoflann.

[1]: https://github.com/jlblancoc/nanoflann/blob/master/CHANGELOG.txt#L34