### PR TITLE
modify SICP::point_to_point() and RigidMotionEstimator::point_to_point() to return the registration transform

### DIFF
--- a/ICP.h
+++ b/ICP.h
@@ -107,7 +107,11 @@ namespace RigidMotionEstimator {
         X.colwise() += X_mean;
         Y.colwise() += Y_mean;
         /// Return transformation
-        return transformation;
+        Eigen::Affine3d trans = Eigen::Affine3d::Identity();
+        trans.translation() = - X_mean;
+        Eigen::Affine3d trans2 = Eigen::Affine3d::Identity();
+        trans2.translation() = X_mean;
+        return trans2 * transformation * trans;
     }
     /// @param Source (one 3D point per column)
     /// @param Target (one 3D point per column)


### PR DESCRIPTION
- RigidMotionEstimator::point_to_point() was not returning the correct transform (offset issue))
- SICP::point_to_point() now simply accumulates transforms for each iteration and returns the result